### PR TITLE
MySQL 8.0 for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) fo
 
 ## Versions
 
-* MySQL: `5.7`
+- MySQL: `8.0`
 
 ## Bug Notice
 

--- a/lib/build_pack/downloader.rb
+++ b/lib/build_pack/downloader.rb
@@ -2,10 +2,10 @@ require 'net/http'
 
 module BuildPack
   class Downloader
-    MYSQL_BASE_URL = "http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/"
+    MYSQL_BASE_URL = "http://security.ubuntu.com/ubuntu/pool/main/m/mysql-8.0/"
 
-    # example client: "mysql-client-5.7_5.7.22-0ubuntu0.16.04.1_amd64.deb"
-    REGEX = /.*(mysql-client-5\.7_5\.7\.\d\d-0ubuntu0\.16\.\d\d\.\d_amd64.deb).*/
+    # example client: "mysql-client-8.0_8.0.23-0ubuntu0.20.04.1_amd64.deb"
+    REGEX = /.*(mysql-client-8\.0_8\.0\.\d\d-0ubuntu0\.20\.04\.\d_amd64.deb).*/
 
     class << self
       def download_latest_client_to(path)

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -22,7 +22,7 @@ module BuildPack
         @tmp_path = "#{build_dir}/tmp"
         @mysql_path = "#{@tmp_path}/mysql"
         @mysql_binaries = "#{@mysql_path}/usr/bin"
-        @mysql_pkg = "#{cache_dir}/mysql.deb"
+        @mysql_pkg = "#{cache_dir}/mysql8.0.deb"
       end
 
       def make_dirs

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -55,16 +55,21 @@ module BuildPack
       end
 
       def fix_perms_and_mv_binaries
+        Logger.log("Directories:")
+        Logger.log("#{Dir.glob("#{@tmp_path}/*")}")
+        Logger.log("#{Dir.glob("#{@mysql_path}/*")}")
+        Logger.log("#{Dir.glob("#{@mysql_path}/usr/*")}")
+        Logger.log("#{Dir.glob("#{@mysql_path}/usr/bin/*")}")
         # TODO: Doing a glob for some reason causes issues on heroku-16,
         #       erroring out as it can't find the files to chmod and mv.
         #       Specifying `mysqldump` specifically for now. Otherwise use:
         # ```
         # binaries = Dir.glob("#{@mysql_binaries}/*")
         # ```
-        mysqldump_binary = Dir.glob("#{@mysql_binaries}/mysqldump")
-        Logger.log("#{mysqldump_binary}")
-        FileUtils.chmod("u=wrx", mysqldump_binary)
-        FileUtils.mv(mysqldump_binary, @bin_path)
+        #mysqldump_binary = Dir.glob("#{@mysql_binaries}/*")
+        #Logger.log("#{mysqldump_binary}")
+        #FileUtils.chmod("u=wrx", mysqldump_binary)
+        #FileUtils.mv(mysqldump_binary, @bin_path)
       end
 
       def cleanup

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -62,6 +62,7 @@ module BuildPack
         # binaries = Dir.glob("#{@mysql_binaries}/*")
         # ```
         mysqldump_binary = Dir.glob("#{@mysql_binaries}/mysqldump")
+        Logger.log("#{mysqldump_binary}")
         FileUtils.chmod("u=wrx", mysqldump_binary)
         FileUtils.mv(mysqldump_binary, @bin_path)
       end


### PR DESCRIPTION
Upgrades the buildpack to use mysql 8.0 and be compatible with the `heroku-20` stack