### PR TITLE
merge the biagri fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 before_install:
   - gem install bundler
 rvm:
-  - '2.3.1'
+  - '2.6.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,37 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    coderay (1.1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    diff-lcs (1.2.5)
-    hashdiff (0.2.3)
-    method_source (0.8.2)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rake (10.5.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    diff-lcs (1.3)
+    hashdiff (1.0.1)
+    method_source (1.0.0)
+    pry (0.13.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (4.0.3)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
-    safe_yaml (1.0.4)
-    slop (3.6.0)
-    webmock (1.22.6)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    safe_yaml (1.0.5)
+    webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -43,4 +43,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://secure.travis-ci.org/Shopify/heroku-buildpack-mysql.png)](http://travis-ci.org/Shopify/heroku-buildpack-mysql)
 
-This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring just the `mysql` binary from the `mysql-client-core` deb package.
+This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring just the `mysql` binary from the `mysql-client` deb package.
 
 ## Versions
 
-* MySQL: `5.7`
+* MySQL: `8.0`
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # heroku-buildpack-mysql
 
-[![Build Status](https://secure.travis-ci.org/Shopify/heroku-buildpack-mysql.png)](http://travis-ci.org/Shopify/heroku-buildpack-mysql)
-
-This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring just the `mysql` binary from the `mysql-client` deb package.
+This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring the `mysql` and `mysqldump` binaries from the `mysql-client` deb package. 
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 [![Build Status](https://secure.travis-ci.org/Shopify/heroku-buildpack-mysql.png)](http://travis-ci.org/Shopify/heroku-buildpack-mysql)
 
-This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring the mysql client binaries into your project.
+This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring just the `mysql` binary from the `mysql-client-core` deb package.
 
 ## Versions
 
 * MySQL: `5.7`
 
-## Bug Notice
-
-This will only copy over `mysqldump` as part of the buildpack for now.

--- a/lib/build_pack/downloader.rb
+++ b/lib/build_pack/downloader.rb
@@ -2,10 +2,10 @@ require 'net/http'
 
 module BuildPack
   class Downloader
-    MYSQL_BASE_URL = "http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/"
+    MYSQL_BASE_URL = "http://security.ubuntu.com/ubuntu/pool/main/m/mysql-8.0/"
 
-    # example client: "mysql-client-core-5.7_5.7.22-0ubuntu0.16.04.1_amd64.deb"
-    REGEX = /.*(mysql-client-core-5\.7_5\.7\.\d\d-0ubuntu0\.18\.\d\d\.\d_amd64.deb).*/
+    # example client: "mysql-client-5.7_5.7.22-0ubuntu0.16.04.1_amd64.deb"
+    REGEX = /.*(mysql-client-8\.0_8\.0\.\d\d-0ubuntu0\.20\.\d\d\.\d_amd64.deb).*/
 
     class << self
       def download_latest_client_to(path)

--- a/lib/build_pack/downloader.rb
+++ b/lib/build_pack/downloader.rb
@@ -4,8 +4,8 @@ module BuildPack
   class Downloader
     MYSQL_BASE_URL = "http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/"
 
-    # example client: "mysql-client-5.7_5.7.22-0ubuntu0.16.04.1_amd64.deb"
-    REGEX = /.*(mysql-client-5\.7_5\.7\.\d\d-0ubuntu0\.16\.\d\d\.\d_amd64.deb).*/
+    # example client: "mysql-client-core-5.7_5.7.22-0ubuntu0.16.04.1_amd64.deb"
+    REGEX = /.*(mysql-client-core-5\.7_5\.7\.\d\d-0ubuntu0\.18\.\d\d\.\d_amd64.deb).*/
 
     class << self
       def download_latest_client_to(path)

--- a/lib/build_pack/downloader.rb
+++ b/lib/build_pack/downloader.rb
@@ -4,8 +4,8 @@ module BuildPack
   class Downloader
     MYSQL_BASE_URL = "http://security.ubuntu.com/ubuntu/pool/main/m/mysql-8.0/"
 
-    # example client: "mysql-client-5.7_5.7.22-0ubuntu0.16.04.1_amd64.deb"
-    REGEX = /.*(mysql-client-8\.0_8\.0\.\d\d-0ubuntu0\.20\.\d\d\.\d_amd64.deb).*/
+    # example client: "mysql-client-core-8.0_8.0.22-0ubuntu0.20.04.1_amd64.deb"
+    REGEX = /.*(mysql-client-core-8\.0_8\.0\.\d\d-0ubuntu0\.20\.\d\d\.\d_amd64.deb).*/
 
     class << self
       def download_latest_client_to(path)

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -61,7 +61,11 @@ module BuildPack
         # ```
         # binaries = Dir.glob("#{@mysql_binaries}/*")
         # ```
-        mysqldump_binary = Dir.glob("#{@mysql_binaries}/mysql")
+        mysql_binary = Dir.glob("#{@mysql_binaries}/mysql")
+        FileUtils.chmod("u=wrx", mysql_binary)
+        FileUtils.mv(mysql_binary, @bin_path)
+        
+        mysqldump_binary = Dir.glob("#{@mysql_binaries}/mysqldump")
         FileUtils.chmod("u=wrx", mysqldump_binary)
         FileUtils.mv(mysqldump_binary, @bin_path)
       end

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -20,9 +20,9 @@ module BuildPack
       def init_paths(build_dir, cache_dir)
         @bin_path = "#{build_dir}/bin"
         @tmp_path = "#{build_dir}/tmp"
-        @mysql_path = "#{@tmp_path}/mysql"
+        @mysql_path = "#{@tmp_path}/mysql-client-core"
         @mysql_binaries = "#{@mysql_path}/usr/bin"
-        @mysql_pkg = "#{cache_dir}/mysql.deb"
+        @mysql_pkg = "#{cache_dir}/mysql-client-core.deb"
       end
 
       def make_dirs
@@ -61,7 +61,7 @@ module BuildPack
         # ```
         # binaries = Dir.glob("#{@mysql_binaries}/*")
         # ```
-        mysqldump_binary = Dir.glob("#{@mysql_binaries}/mysqldump")
+        mysqldump_binary = Dir.glob("#{@mysql_binaries}/mysql")
         FileUtils.chmod("u=wrx", mysqldump_binary)
         FileUtils.mv(mysqldump_binary, @bin_path)
       end

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -20,9 +20,9 @@ module BuildPack
       def init_paths(build_dir, cache_dir)
         @bin_path = "#{build_dir}/bin"
         @tmp_path = "#{build_dir}/tmp"
-        @mysql_path = "#{@tmp_path}/mysql-client"
+        @mysql_path = "#{@tmp_path}/mysql-client-core"
         @mysql_binaries = "#{@mysql_path}/usr/bin"
-        @mysql_pkg = "#{cache_dir}/mysql-client.deb"
+        @mysql_pkg = "#{cache_dir}/mysql-client-core.deb"
       end
 
       def make_dirs

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -20,9 +20,9 @@ module BuildPack
       def init_paths(build_dir, cache_dir)
         @bin_path = "#{build_dir}/bin"
         @tmp_path = "#{build_dir}/tmp"
-        @mysql_path = "#{@tmp_path}/mysql-client-core"
+        @mysql_path = "#{@tmp_path}/mysql-client"
         @mysql_binaries = "#{@mysql_path}/usr/bin"
-        @mysql_pkg = "#{cache_dir}/mysql-client-core.deb"
+        @mysql_pkg = "#{cache_dir}/mysql-client.deb"
       end
 
       def make_dirs

--- a/spec/build_pack/downloader_spec.rb
+++ b/spec/build_pack/downloader_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 describe BuildPack::Downloader do
   context "when there are several packages available" do
     it "picks the most recent amd64 package" do
-      stub_request_to_debian_base_url(Helpers::RESPONSE_WITH_SUITABLE_CLIENTS)
-
+      stub_request_to_ubuntu_base_url(Helpers::RESPONSE_WITH_SUITABLE_CLIENTS)
       expect(BuildPack::Downloader.most_recent_client).to eql("#{Helpers::EXPECTED_PACKAGED}")
     end
   end

--- a/spec/build_pack/installer_spec.rb
+++ b/spec/build_pack/installer_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 TMP_DIR = "tmp"
 CACHE_DIR = "#{TMP_DIR}/cache_dir"
 BUILD_DIR = "#{TMP_DIR}/build_dir"
-DPKG_BIN_DIR = "#{BUILD_DIR}/tmp/mysql/usr/bin"
-DPKG_BIN_OUTPUT = "#{DPKG_BIN_DIR}/fake_binary"
-MYSQL_INSTALLED_BINARY = "#{BUILD_DIR}/bin/fake_binary"
+DPKG_BIN_DIR = "#{BUILD_DIR}/tmp/mysql-client-core/usr/bin"
+DPKG_BIN_OUTPUT = "#{DPKG_BIN_DIR}/mysql"
+MYSQL_INSTALLED_BINARY = "#{BUILD_DIR}/bin/mysql"
 
-EXPECTED_DEB_COMMAND = "dpkg -x #{CACHE_DIR}/mysql.deb #{BUILD_DIR}/tmp/mysql"
+EXPECTED_DEB_COMMAND = "dpkg -x #{CACHE_DIR}/mysql-client-core.deb #{BUILD_DIR}/tmp/mysql-client-core"
 STUBBED_DEB_COMMAND = "mkdir -p #{DPKG_BIN_DIR}; touch #{DPKG_BIN_OUTPUT}"
 
 describe BuildPack::Installer do
@@ -17,7 +17,7 @@ describe BuildPack::Installer do
   after{`rm -r #{TMP_DIR}`}
 
   context "when cache already has client" do
-    before{`touch #{CACHE_DIR}/mysql.deb`}
+    before{`touch #{CACHE_DIR}/mysql-client-core.deb`}
 
     it "installs cached client" do
       expect(described_class).to receive(:`).with(EXPECTED_DEB_COMMAND) {`#{STUBBED_DEB_COMMAND}`}
@@ -30,7 +30,7 @@ describe BuildPack::Installer do
 
   context "when cache does not have client " do
     it "downloads and installs available client" do
-      stub_request_to_debian_base_url(Helpers::RESPONSE_WITH_SUITABLE_CLIENTS)
+      stub_request_to_ubuntu_base_url(Helpers::RESPONSE_WITH_SUITABLE_CLIENTS)
       stub_request_for_expected_package
 
       BuildPack::Installer.install(BUILD_DIR, CACHE_DIR)
@@ -39,7 +39,7 @@ describe BuildPack::Installer do
     end
 
     it "it does not attempt to install when there are no available clients" do
-      stub_request_to_debian_base_url(Helpers::RESPONSE_WITHOUT_SUITABLE_CLIENTS)
+      stub_request_to_ubuntu_base_url(Helpers::RESPONSE_WITHOUT_SUITABLE_CLIENTS)
 
       expect{BuildPack::Installer.install(BUILD_DIR, CACHE_DIR)}.to raise_error(SystemExit)
 

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,43 +1,34 @@
 module Helpers
 
-  EXPECTED_PACKAGED = "mysql-client-5.5_5.5.62-0+deb7u1_amd64.deb"
+  EXPECTED_PACKAGED = "mysql-client-core-5.7_5.7.29-0ubuntu0.18.04.1_amd64.deb"
 
   RESPONSE_WITH_SUITABLE_CLIENTS =
   %{
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb">mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb</a></td><td align="right">2016-01-27 20:58  </td><td align="right">2.0M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-amd64.deb">mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-amd64.deb</a></td><td align="right">2016-01-27 19:38  </td><td align="right">1.6M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-i386.deb">mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-i386.deb</a></td><td align="right">2016-01-27 17:58  </td><td align="right">1.5M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_mips.deb">mysql-client-5.5_5.5.47-0+deb7u1_mips.deb</a></td><td align="right">2016-01-27 22:28  </td><td align="right">1.5M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_mipsel.deb">mysql-client-5.5_5.5.47-0+deb7u1_mipsel.deb</a></td><td align="right">2016-01-27 22:28  </td><td align="right">1.5M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_powerpc.deb">mysql-client-5.5_5.5.47-0+deb7u1_powerpc.deb</a></td><td align="right">2016-01-27 18:28  </td><td align="right">1.3M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_s390.deb">mysql-client-5.5_5.5.47-0+deb7u1_s390.deb</a></td><td align="right">2016-01-27 18:13  </td><td align="right">1.6M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.51-0+deb8u1_amd64.deb">mysql-client-5.5_5.5.51-0+deb8u1_amd64.deb</a></td><td align="right">2016-09-14 06:11  </td><td align="right">1.6M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_s390x.deb">mysql-client-5.5_5.5.47-0+deb7u1_s390x.deb</a></td><td align="right">2016-01-27 18:43  </td><td align="right">1.6M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_sparc.deb">mysql-client-5.5_5.5.47-0+deb7u1_sparc.deb</a></td><td align="right">2016-01-27 23:28  </td><td align="right">1.4M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.62-0+deb7u1_amd64.deb">mysql-client-5.5_5.5.62-0+deb7u1_amd64.deb</a></td><td align="right">2016-09-16 15:07  </td><td align="right">1.7M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb7u1_armel.deb">mysql-client-5.5_5.5.52-0+deb7u1_armel.deb</a></td><td align="right">2016-09-16 18:27  </td><td align="right">1.4M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb7u1_armhf.deb">mysql-client-5.5_5.5.52-0+deb7u1_armhf.deb</a></td><td align="right">2016-09-16 18:27  </td><td align="right">1.4M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb7u1_i386.deb">mysql-client-5.5_5.5.52-0+deb7u1_i386.deb</a></td><td align="right">2016-09-16 16:57  </td><td align="right">1.5M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.50-0+deb8u1_amd64.deb">mysql-client-5.5_5.5.50-0+deb8u1_amd64.deb</a></td><td align="right">2016-09-14 06:11  </td><td align="right">1.6M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_arm64.deb">mysql-client-5.5_5.5.52-0+deb8u1_arm64.deb</a></td><td align="right">2016-09-14 06:26  </td><td align="right">1.4M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_armel.deb">mysql-client-5.5_5.5.52-0+deb8u1_armel.deb</a></td><td align="right">2016-09-14 07:26  </td><td align="right">1.4M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_armhf.deb">mysql-client-5.5_5.5.52-0+deb8u1_armhf.deb</a></td><td align="right">2016-09-16 15:57  </td><td align="right">1.4M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_i386.deb">mysql-client-5.5_5.5.52-0+deb8u1_i386.deb</a></td><td align="right">2016-09-14 05:56  </td><td align="right">1.6M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-amd64.deb">mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-amd64.deb</a></td><td align="right">2016-09-14 16:57  </td><td align="right">1.5M</td></tr>
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-i386.deb">mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-i386.deb</a></td><td align="right">2016-09-14 17:12  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.11-0ubuntu6_amd64.deb">mysql-client-core-5.7_5.7.11-0ubuntu6_amd64.deb</a></td><td align="right">2016-04-14 05:15  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.11-0ubuntu6_i386.deb">mysql-client-core-5.7_5.7.11-0ubuntu6_i386.deb</a></td><td align="right">2016-04-14 05:55  </td><td align="right">1.7M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.21-1ubuntu1_amd64.deb">mysql-client-core-5.7_5.7.21-1ubuntu1_amd64.deb</a></td><td align="right">2018-02-05 17:08  </td><td align="right">2.2M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.21-1ubuntu1_i386.deb">mysql-client-core-5.7_5.7.21-1ubuntu1_i386.deb</a></td><td align="right">2018-02-05 16:59  </td><td align="right">2.2M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.25-1_amd64.deb">mysql-client-core-5.7_5.7.25-1_amd64.deb</a></td><td align="right">2019-01-29 05:38  </td><td align="right">2.2M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.25-1_i386.deb">mysql-client-core-5.7_5.7.25-1_i386.deb</a></td><td align="right">2019-01-29 05:53  </td><td align="right">2.3M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.28-0ubuntu0.19.04.2_amd64.deb">mysql-client-core-5.7_5.7.28-0ubuntu0.19.04.2_amd64.deb</a></td><td align="right">2019-11-18 12:34  </td><td align="right">1.8M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.28-0ubuntu0.19.04.2_i386.deb">mysql-client-core-5.7_5.7.28-0ubuntu0.19.04.2_i386.deb</a></td><td align="right">2019-11-18 12:34  </td><td align="right">1.9M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.29-0ubuntu0.16.04.1_amd64.deb">mysql-client-core-5.7_5.7.29-0ubuntu0.16.04.1_amd64.deb</a></td><td align="right">2020-01-27 15:03  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.29-0ubuntu0.16.04.1_i386.deb">mysql-client-core-5.7_5.7.29-0ubuntu0.16.04.1_i386.deb</a></td><td align="right">2020-01-27 15:03  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.29-0ubuntu0.18.04.1_amd64.deb">mysql-client-core-5.7_5.7.29-0ubuntu0.18.04.1_amd64.deb</a></td><td align="right">2020-01-27 15:04  </td><td align="right">1.9M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.7_5.7.29-0ubuntu0.18.04.1_i386.deb">mysql-client-core-5.7_5.7.29-0ubuntu0.18.04.1_i386.deb</a></td><td align="right">2020-01-27 15:04  </td><td align="right">1.9M</td></tr>
   }
 
 RESPONSE_WITHOUT_SUITABLE_CLIENTS =
   %{
-  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb">mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb</a></td><td align="right">2016-01-27 20:58  </td><td align="right">2.0M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-core-5.5_5.5.47-0+deb7u1_ia64.deb">mysql-client-core-5.5_5.5.47-0+deb7u1_ia64.deb</a></td><td align="right">2016-01-27 20:58  </td><td align="right">2.0M</td></tr>
   }
 
-  def stub_request_to_debian_base_url(response)
+  def stub_request_to_ubuntu_base_url(response)
     stub_request(:get, BuildPack::Downloader::MYSQL_BASE_URL).
       with(:headers => {
         'Accept'=>'*/*',
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Host'=>'security.debian.org',
+        'Host'=>'security.ubuntu.com',
         'User-Agent'=>'Ruby'}).
       to_return(
         :status => 200,
@@ -50,7 +41,7 @@ RESPONSE_WITHOUT_SUITABLE_CLIENTS =
       with(:headers => {
         'Accept'=>'*/*',
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Host'=>'security.debian.org',
+        'Host'=>'security.ubuntu.com',
         'User-Agent'=>'Ruby'}).
       to_return(
         :status => 200,


### PR DESCRIPTION
- Updates the mysql version: 5.7 -> 8.0
- Fixes issues with postdeploy scripts erroring when trying to run `mysqldump` in the heroku-20 stack

Pulls in changes from https://github.com/biagri/heroku-buildpack-mysql

Thank you @jho406 and @maallard